### PR TITLE
Fix(VIP_Test): Check AuthID before give VIP_Test

### DIFF
--- a/addons/sourcemod/scripting/VIP_Test.sp
+++ b/addons/sourcemod/scripting/VIP_Test.sp
@@ -28,6 +28,9 @@
 				Добавлена поддержка MySQL.
 				Изменено сообщение в лог.
 		1.0.4 - Update syntax to SM 1.11
+		1.0.5 - Check if SteamID is valid to give VIP Test.
+				Translations from CRLF to LF.
+				French translate
 */
 #pragma semicolon 1
 #pragma newdecls required
@@ -40,7 +43,7 @@ public Plugin myinfo =
 	name = "[VIP] Test",
 	author = "Loneypro",
 	description = "Players can test vip features for a set of time",
-	version = "1.0.4",
+	version = "1.0.5",
 	url = ""
 };
 
@@ -195,9 +198,17 @@ public Action TestVIP_CMD(int iClient, int args)
 		{
 			char sQuery[256], sAuth[32];
 		//	GetClientAuthString(iClient, sAuth, sizeof(sAuth));
-			GetClientAuthId(iClient, AuthId_Steam2, sAuth, sizeof(sAuth));
-			FormatEx(sQuery, sizeof(sQuery), "SELECT `end` FROM `vip_test` WHERE `auth` = '%s' LIMIT 1;", sAuth);
-			SQL_TQuery(g_hDatabase, SQL_Callback_SelectClient, sQuery, GetClientUserId(iClient));
+		//	GetClientAuthId(iClient, AuthId_Steam2, sAuth, sizeof(sAuth));
+			if (!GetClientAuthId(iClient, AuthId_Steam2, sAuth, sizeof(sAuth), true))
+			{
+				VIP_PrintToChatClient(iClient, "%t", "VIP_AUTH_FAILED");
+				return Plugin_Handled;
+			}
+			else
+			{
+				FormatEx(sQuery, sizeof(sQuery), "SELECT `end` FROM `vip_test` WHERE `auth` = '%s' LIMIT 1;", sAuth);
+				SQL_TQuery(g_hDatabase, SQL_Callback_SelectClient, sQuery, GetClientUserId(iClient));
+			}
 		}
 		else
 		{

--- a/addons/sourcemod/translations/vip_test.phrases.txt
+++ b/addons/sourcemod/translations/vip_test.phrases.txt
@@ -2,23 +2,34 @@
 {
 	"VIP_ALREADY"
 	{
-		"ru"	"Вы уже являетесь VIP игроком!"
-		"en"	"You are VIP already!"
-		"fi"	"Olet VIP Jo!
+		"ru"	"Вы уже являетесь VIP игроком!"
+		"en"	"You are VIP already!"
+		"fi"	"Olet VIP Jo!
+		"fr"	"Vous êtes déjà VIP !"
 	}
 
 	"VIP_RENEWAL_IS_NOT_AVAILABLE_YET"
 	{
 		"#format"	"{1:s}"
-		"ru"	"Повторно попробовать VIP функции можно будет через {1}!"
-		"en"	"Trying VIP features again will be available in {1}!"
-		"fi"	"Pystyt hankkimaan uudelleen vasta kun VIP tulee olemaan saatavilla {1} päästä!"
+		"ru"	"Повторно попробовать VIP функции можно будет через {1}!"
+		"en"	"Trying VIP features again will be available in {1}!"
+		"fi"	"Pystyt hankkimaan uudelleen vasta kun VIP tulee olemaan saatavilla {1} päästä!"
+		"fr"	"Réessayer dans un instant. Les fonctionnalités VIP sera disponible dans {1}!"
 	}
 
 	"VIP_RENEWAL_IS_DISABLED"
 	{
-		"ru"	"Повторное получение VIP-статуса запрещено!"
-		"en"	"VIP renewal is disabled!"
-		"fi"	"VIP uusiminen ei ole käytössä!"
+		"ru"	"Повторное получение VIP-статуса запрещено!"
+		"en"	"VIP renewal is disabled!"
+		"fi"	"VIP uusiminen ei ole käytössä!"
+		"fr"	"Le renouvellement VIP est désactivé !"
+	}
+
+	"VIP_AUTH_FAILED"
+	{
+		"ru"	"Не удалось подтвердить ваш SteamID. Попробуй позже."
+		"en"	"Unable to verify your SteamID. Try later."
+		"fi"	"SteamID:n vahvistaminen epäonnistui. Yritä myöhemmin."
+		"fr"	"Impossible de vérifier votre SteamID. Essayer plus tard."
 	}
 }


### PR DESCRIPTION
Check if SteamID is valid to give VIP Test. See more.. https://github.com/srcdslab/sm-plugin-VIP_Test/issues/3
Translations from CRLF to LF
Add French translate support